### PR TITLE
Define user to root in Dockerfile for JDK8

### DIFF
--- a/jdk8/Dockerfile
+++ b/jdk8/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ENV USER root 
+
 # Install AOSP dependencies
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \


### PR DESCRIPTION
Add a line of "ENV USER root" to work around below problem encountered while compiling branch android-8.1.0_r1

 `Still: out/host/linux-x86/bin/jack: line 80: USER: unbound variable`